### PR TITLE
Country name misspellings

### DIFF
--- a/questions/058.txt
+++ b/questions/058.txt
@@ -420,7 +420,7 @@ Who ran unsuccesfully against Regan in 1984`Walter Mondale
 On what date did "The Wall" fall`1989
 Biko was involved in what protest movement`Apartheid
 What was the fight between Argentina and Great Britan over`Faulkland Islands
-Live Aid was to benefit which starving country`Ethopia
+Live Aid was to benefit which starving country`Ethiopia
 What did Regan due to the striking air traffic controllers`Fired them
 Mark David Chapman was famous for what in 1980`Shooting John Lennon
 What was the name of Garfield's vet`Liz

--- a/questions/065.txt
+++ b/questions/065.txt
@@ -107,7 +107,7 @@ Who ran unsuccesfully against Regan in 1984?`Walter Mondale
 On what date did "The Wall" fall?`1989
 Biko was involved in what protest movement?`Apartheid
 What was the fight between Argentina and Great Britan over?`Faulkland Islands
-Live Aid was to benefit which starving country?`Ethopia
+Live Aid was to benefit which starving country?`Ethiopia
 What did Regan due to the striking air traffic controllers?`Fired them
 Mark David Chapman was famous for what in 1980?`Shooting John Lennon
 What was the name of Garfield's vet?`Liz

--- a/questions/random.txt
+++ b/questions/random.txt
@@ -9372,7 +9372,7 @@ Who ran unsuccesfully against Regan in 1984?`Walter Mondale
 On what date did "The Wall" fall?`1989
 Biko was involved in what protest movement?`Apartheid
 What was the fight between Argentina and Great Britan over?`Faulkland Islands
-Live Aid was to benefit which starving country?`Ethopia
+Live Aid was to benefit which starving country?`Ethiopia
 What did Regan due to the striking air traffic controllers?`Fired them
 Mark David Chapman was famous for what in 1980?`Shooting John Lennon
 What was the name of Garfield's vet?`Liz


### PR DESCRIPTION
_Ethiopia_ was misspelled as _Ethopia_, with no middle **i**.
